### PR TITLE
Fix auto-scroll issue when adding tasks to different days

### DIFF
--- a/frontend/src/components/todos/TaskListContainer.tsx
+++ b/frontend/src/components/todos/TaskListContainer.tsx
@@ -32,6 +32,9 @@ export const TaskListContainer: React.FC = () => {
   // Reference to the "today" day container for auto-scrolling
   const todayRef = useRef<HTMLDivElement>(null);
   
+  // Ref to track if component has mounted
+  const hasMountedRef = useRef<boolean>(false);
+  
   // Generate date array for the fixed range
   const dateArray = React.useMemo(() => {
     const today = new Date();
@@ -71,16 +74,25 @@ export const TaskListContainer: React.FC = () => {
     fetchTasks();
   }, [fetchTasks]);
   
-  // Auto-scroll to today's tasks when component mounts and tasks are loaded
+  // Auto-scroll to today's tasks ONLY when component initially mounts and tasks are loaded
   useEffect(() => {
-    if (!loading && !error && tasks.length > 0 && todayRef.current) {
+    // Only scroll if:
+    // 1. Component hasn't mounted yet
+    // 2. Not loading
+    // 3. No errors
+    // 4. We have tasks
+    // 5. Today's element exists
+    if (!hasMountedRef.current && !loading && !error && tasks.length > 0 && todayRef.current) {
       // Scroll to the today element with a small offset to position it at the top
       todayRef.current.scrollIntoView({
         behavior: 'smooth',
         block: 'start'
       });
+      
+      // Mark as mounted so we don't auto-scroll again
+      hasMountedRef.current = true;
     }
-  }, [loading, error, tasks.length]);
+  }, [loading, error]); // Removed tasks.length dependency
 
   // Task action handlers
   const handleAddTaskClick = (day: string) => {


### PR DESCRIPTION
This PR fixes an issue where adding a task on a different day would automatically scroll back to today after saving.

## Problem
The auto-scroll useEffect in TaskListContainer had `tasks.length` in its dependency array, causing it to run whenever any task was added, regardless of which day it was for.

## Solution
- Added a ref to track if the component has already mounted
- Modified the useEffect to only scroll on initial mount
- Removed `tasks.length` from the dependency array

Now users can add tasks to any day without being automatically scrolled back to today, while still maintaining the initial auto-scroll when the app first loads.