### PR TITLE
Fix task rollover timezone

### DIFF
--- a/backend/src/__tests__/taskRollover.test.ts
+++ b/backend/src/__tests__/taskRollover.test.ts
@@ -1,0 +1,623 @@
+import { jest, describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { TaskService } from '../services/taskService';
+import { prisma } from '../lib/prisma';
+import type { Task } from '@prisma/client';
+
+// Mock Prisma
+jest.mock('../lib/prisma', () => ({
+  prisma: {
+    task: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn()
+    }
+  }
+}));
+
+// Use any type for mocks to avoid TypeScript errors in tests
+const mockPrismaTask = prisma.task as any;
+
+describe('TaskService Rollover Functionality', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Reset the TaskService's prisma instance to use our mock
+    TaskService.resetPrisma();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('rollOverTasks', () => {
+    it('should not move completed tasks', async () => {
+      // Create a mix of complete and incomplete tasks for yesterday
+      const yesterday = new Date('2025-04-28T07:00:00.000-07:00'); // PT timezone
+      const today = new Date('2025-04-29T07:00:00.000-07:00'); // PT timezone
+      
+      const completedTask: Task = {
+        id: 'completed-task',
+        title: 'Completed Task',
+        status: 'complete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: new Date('2025-04-28T15:00:00.000-07:00'),
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      const incompleteTask: Task = {
+        id: 'incomplete-task',
+        title: 'Incomplete Task',
+        status: 'incomplete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 10,
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return our tasks when querying for yesterday's tasks
+      // Mock findMany to return different results based on the query
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // For finding incomplete tasks from yesterday
+        if (params.where.status === 'incomplete') {
+          return [incompleteTask];
+        }
+        
+        // For finding tasks on the target date (to determine display order)
+        return [];
+      });
+      
+      // Mock update to return the updated task
+      mockPrismaTask.update.mockImplementation((params: any) => {
+        const taskId = params.where.id;
+        const updatedData = params.data;
+        
+        if (taskId === 'incomplete-task') {
+          return {
+            ...incompleteTask,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        return null;
+      });
+      
+      // Execute rollover
+      const rolledOverCount = await TaskService.rollOverTasks(yesterday, today);
+      
+      // Verify only incomplete tasks were moved
+      expect(rolledOverCount).toBe(1);
+      expect(mockPrismaTask.update).toHaveBeenCalledTimes(1);
+      expect(mockPrismaTask.update).toHaveBeenCalledWith({
+        where: { id: 'incomplete-task' },
+        data: expect.objectContaining({
+          dueDate: today,
+          isRolledOver: true,
+          displayOrder: expect.any(Number)
+        })
+      });
+      
+      // Verify completed tasks were not moved
+      expect(mockPrismaTask.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'completed-task' }
+        })
+      );
+    });
+    
+    it('should move tasks only to the next day (yesterday to today)', async () => {
+      // Create tasks for yesterday, today, and tomorrow
+      const yesterday = new Date('2025-04-28T07:00:00.000-07:00'); // PT timezone
+      const today = new Date('2025-04-29T07:00:00.000-07:00'); // PT timezone
+      const tomorrow = new Date('2025-04-30T07:00:00.000-07:00'); // PT timezone
+      
+      const yesterdayTask: Task = {
+        id: 'yesterday-task',
+        title: 'Yesterday Task',
+        status: 'incomplete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return our tasks
+      // Mock findMany to return different results based on the query
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // For finding incomplete tasks from yesterday
+        if (params.where.status === 'incomplete') {
+          return [yesterdayTask];
+        }
+        
+        // For finding tasks on the target date (to determine display order)
+        return [];
+      });
+      
+      // Mock update to return the updated task
+      mockPrismaTask.update.mockImplementation((params: any) => {
+        const taskId = params.where.id;
+        const updatedData = params.data;
+        
+        if (taskId === 'yesterday-task') {
+          return {
+            ...yesterdayTask,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        return null;
+      });
+      
+      // Execute rollover from yesterday to today
+      const rolledOverCount = await TaskService.rollOverTasks(yesterday, today);
+      
+      // Verify task was moved to today
+      expect(rolledOverCount).toBe(1);
+      expect(mockPrismaTask.update).toHaveBeenCalledWith({
+        where: { id: 'yesterday-task' },
+        data: expect.objectContaining({
+          dueDate: today,
+          isRolledOver: true
+        })
+      });
+      
+      // Reset mocks for next test
+      jest.clearAllMocks();
+      
+      // Now try to roll over from yesterday to tomorrow (should not happen in real app)
+      // This is just to verify the implementation doesn't have a bug that would allow this
+      await TaskService.rollOverTasks(yesterday, tomorrow);
+      
+      // Verify the task was moved to the specified date (tomorrow)
+      // This is testing that the implementation doesn't enforce "only next day" on its own
+      // The app should ensure this by only calling rollOverTasks with yesterday and today
+      expect(mockPrismaTask.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'yesterday-task' },
+          data: expect.objectContaining({
+            dueDate: tomorrow
+          })
+        })
+      );
+    });
+    
+    it('should mark rolled over tasks with isRolledOver flag', async () => {
+      const yesterday = new Date('2025-04-28T07:00:00.000-07:00'); // PT timezone
+      const today = new Date('2025-04-29T07:00:00.000-07:00'); // PT timezone
+      
+      const incompleteTask: Task = {
+        id: 'incomplete-task',
+        title: 'Incomplete Task',
+        status: 'incomplete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false, // Initially not rolled over
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return our task
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // First call: finding incomplete tasks for yesterday
+        if (params.where.status === 'incomplete') {
+          return [incompleteTask];
+        }
+        
+        // Second call: finding tasks for target date (today)
+        return [];
+      });
+      
+      // Mock update to return the updated task
+      mockPrismaTask.update.mockImplementation((params: any) => {
+        const taskId = params.where.id;
+        const updatedData = params.data;
+        
+        if (taskId === 'incomplete-task') {
+          return {
+            ...incompleteTask,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        return null;
+      });
+      
+      // Execute rollover
+      await TaskService.rollOverTasks(yesterday, today);
+      
+      // Verify task was marked as rolled over
+      expect(mockPrismaTask.update).toHaveBeenCalledWith({
+        where: { id: 'incomplete-task' },
+        data: expect.objectContaining({
+          isRolledOver: true
+        })
+      });
+    });
+    
+    it('should add rolled over tasks to the bottom of existing tasks on the new day', async () => {
+      const yesterday = new Date('2025-04-28T07:00:00.000-07:00'); // PT timezone
+      const today = new Date('2025-04-29T07:00:00.000-07:00'); // PT timezone
+      
+      const incompleteTask1: Task = {
+        id: 'incomplete-task-1',
+        title: 'Incomplete Task 1',
+        status: 'incomplete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      const incompleteTask2: Task = {
+        id: 'incomplete-task-2',
+        title: 'Incomplete Task 2',
+        status: 'incomplete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: true,
+        createdAt: new Date('2025-04-28T11:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 10,
+        userId: 'test-user-id'
+      };
+      
+      const existingTodayTask: Task = {
+        id: 'today-task',
+        title: 'Today Task',
+        status: 'incomplete',
+        dueDate: today,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-29T09:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 50, // Highest display order for today
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return our tasks
+      // Mock findMany to return different results based on the query
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // For finding incomplete tasks from yesterday
+        if (params.where.status === 'incomplete') {
+          return [incompleteTask1, incompleteTask2];
+        }
+        
+        // For finding tasks on the target date (to determine display order)
+        if (!params.where.status) {
+          return [existingTodayTask];
+        }
+        
+        return [];
+      });
+      
+      // Mock update to return the updated tasks
+      const updatedTasks: Task[] = [];
+      mockPrismaTask.update.mockImplementation((params: any) => {
+        const taskId = params.where.id;
+        const updatedData = params.data;
+        
+        let updatedTask;
+        if (taskId === 'incomplete-task-1') {
+          updatedTask = {
+            ...incompleteTask1,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        } else if (taskId === 'incomplete-task-2') {
+          updatedTask = {
+            ...incompleteTask2,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        if (updatedTask) {
+          updatedTasks.push(updatedTask);
+          return updatedTask;
+        }
+        
+        return null;
+      });
+      
+      // Execute rollover
+      await TaskService.rollOverTasks(yesterday, today);
+      
+      // Verify tasks were added to the bottom (higher display order than existing tasks)
+      expect(mockPrismaTask.update).toHaveBeenCalledTimes(2);
+      
+      // Get the display orders from the update calls
+      const updateCalls = mockPrismaTask.update.mock.calls;
+      const displayOrders = updateCalls.map((call: any) => call[0].data.displayOrder);
+      
+      // Both should be greater than the existing task's display order (50)
+      expect(displayOrders[0]).toBeGreaterThan(50);
+      expect(displayOrders[1]).toBeGreaterThan(50);
+      
+      // And they should be in sequence with a gap of 10
+      expect(displayOrders[1] - displayOrders[0]).toBe(10);
+    });
+    
+    it('should not move tasks from days other than the specified fromDate', async () => {
+      const twoDaysAgo = new Date('2025-04-27T07:00:00.000-07:00'); // PT timezone
+      const yesterday = new Date('2025-04-28T07:00:00.000-07:00'); // PT timezone
+      const today = new Date('2025-04-29T07:00:00.000-07:00'); // PT timezone
+      
+      const twoDaysAgoTask: Task = {
+        id: 'two-days-ago-task',
+        title: 'Two Days Ago Task',
+        status: 'incomplete',
+        dueDate: twoDaysAgo,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-27T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      const yesterdayTask: Task = {
+        id: 'yesterday-task',
+        title: 'Yesterday Task',
+        status: 'incomplete',
+        dueDate: yesterday,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return our tasks
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // For finding incomplete tasks from yesterday
+        if (params.where.status === 'incomplete') {
+          return [yesterdayTask];
+        }
+        
+        // For finding tasks on the target date (to determine display order)
+        return [];
+      });
+      
+      // Mock update to track which tasks are updated
+      mockPrismaTask.update.mockImplementation((params: any) => {
+        const taskId = params.where.id;
+        const updatedData = params.data;
+        
+        if (taskId === 'yesterday-task') {
+          return {
+            ...yesterdayTask,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        if (taskId === 'two-days-ago-task') {
+          return {
+            ...twoDaysAgoTask,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        return null;
+      });
+      
+      // Execute rollover from yesterday to today
+      await TaskService.rollOverTasks(yesterday, today);
+      
+      // Verify only yesterday's task was moved
+      expect(mockPrismaTask.update).toHaveBeenCalledTimes(1);
+      expect(mockPrismaTask.update).toHaveBeenCalledWith({
+        where: { id: 'yesterday-task' },
+        data: expect.objectContaining({
+          dueDate: today,
+          isRolledOver: true
+        })
+      });
+      
+      // Verify two days ago task was not moved
+      expect(mockPrismaTask.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'two-days-ago-task' }
+        })
+      );
+    });
+    
+    it('should respect Pacific timezone when determining day boundaries', async () => {
+      // Create a date that's midnight in PT
+      const yesterdayPT = new Date('2025-04-28T00:00:00.000-07:00'); // Midnight PT
+      const todayPT = new Date('2025-04-29T00:00:00.000-07:00'); // Midnight PT
+      
+      // Create a task due yesterday late night in PT
+      const lateNightTask: Task = {
+        id: 'late-night-task',
+        title: 'Late Night Task',
+        status: 'incomplete',
+        dueDate: new Date('2025-04-28T23:59:59.999-07:00'), // 11:59:59.999 PM PT
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T22:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return our task
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // First call: finding incomplete tasks for yesterday
+        if (params.where.status === 'incomplete') {
+          // Verify the date boundaries are in PT
+          const startDate = params.where.dueDate.gte;
+          const endDate = params.where.dueDate.lte;
+          
+          // Log for debugging
+          console.log('Query date boundaries:', {
+            start: startDate.toISOString(),
+            end: endDate.toISOString(),
+            taskDueDate: lateNightTask.dueDate.toISOString()
+          });
+          
+          // The start date should be 00:00:00 PT (07:00:00 UTC)
+          expect(startDate.toISOString()).toBe('2025-04-28T07:00:00.000Z');
+          
+          // The end date should be 23:59:59.999 PT (06:59:59.999 UTC next day)
+          expect(endDate.toISOString()).toBe('2025-04-29T06:59:59.999Z');
+          
+          return [lateNightTask];
+        }
+        
+        // Second call: finding tasks for target date (today)
+        return [];
+      });
+      
+      // Mock update to return the updated task
+      mockPrismaTask.update.mockImplementation((params: any) => {
+        const taskId = params.where.id;
+        const updatedData = params.data;
+        
+        if (taskId === 'late-night-task') {
+          return {
+            ...lateNightTask,
+            dueDate: updatedData.dueDate,
+            isRolledOver: updatedData.isRolledOver,
+            displayOrder: updatedData.displayOrder
+          };
+        }
+        
+        return null;
+      });
+      
+      // Execute rollover
+      await TaskService.rollOverTasks(yesterdayPT, todayPT);
+      
+      // Verify task was moved correctly
+      expect(mockPrismaTask.update).toHaveBeenCalledWith({
+        where: { id: 'late-night-task' },
+        data: expect.objectContaining({
+          dueDate: todayPT,
+          isRolledOver: true
+        })
+      });
+    });
+  });
+  
+  describe('getTasksToRollOver', () => {
+    it('should only return incomplete tasks from yesterday in PT timezone', async () => {
+      // Mock the current time to be 12:30 AM PT on April 29, 2025
+      const mockCurrentTime = new Date('2025-04-29T00:30:00.000-07:00');
+      const originalDateNow = Date.now;
+      Date.now = jest.fn(() => mockCurrentTime.getTime());
+      
+      // Yesterday in PT would be April 28, 2025
+      const yesterdayPT = new Date('2025-04-28T12:00:00.000-07:00');
+      
+      // Create tasks with various statuses and dates
+      const yesterdayCompleteTask: Task = {
+        id: 'yesterday-complete',
+        title: 'Yesterday Complete',
+        status: 'complete',
+        dueDate: yesterdayPT,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: new Date('2025-04-28T15:00:00.000-07:00'),
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      const yesterdayIncompleteTask: Task = {
+        id: 'yesterday-incomplete',
+        title: 'Yesterday Incomplete',
+        status: 'incomplete',
+        dueDate: yesterdayPT,
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-28T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 10,
+        userId: 'test-user-id'
+      };
+      
+      const twoDaysAgoIncompleteTask: Task = {
+        id: 'two-days-ago-incomplete',
+        title: 'Two Days Ago Incomplete',
+        status: 'incomplete',
+        dueDate: new Date('2025-04-27T12:00:00.000-07:00'),
+        category: 'Roo Code',
+        isPriority: false,
+        createdAt: new Date('2025-04-27T10:00:00.000-07:00'),
+        completedAt: null,
+        isRolledOver: false,
+        displayOrder: 0,
+        userId: 'test-user-id'
+      };
+      
+      // Mock findMany to return only yesterday's incomplete tasks
+      mockPrismaTask.findMany.mockImplementation((params: any) => {
+        // Verify we're querying for incomplete tasks
+        expect(params.where.status).toBe('incomplete');
+        
+        // Verify the date boundaries are in PT
+        const startDate = params.where.dueDate.gte;
+        const endDate = params.where.dueDate.lte;
+        
+        // The start date should be 00:00:00 PT yesterday (07:00:00 UTC)
+        expect(startDate.toISOString()).toBe('2025-04-28T07:00:00.000Z');
+        
+        // The end date should be 23:59:59.999 PT yesterday (06:59:59.999 UTC today)
+        expect(endDate.toISOString()).toBe('2025-04-29T06:59:59.999Z');
+        
+        return [yesterdayIncompleteTask];
+      });
+      
+      // Execute getTasksToRollOver
+      const tasksToRollOver = await TaskService.getTasksToRollOver();
+      
+      // Verify only yesterday's incomplete task is returned
+      expect(tasksToRollOver).toHaveLength(1);
+      expect(tasksToRollOver[0].id).toBe('yesterday-incomplete');
+      
+      // Restore original Date.now
+      Date.now = originalDateNow;
+    });
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,11 +12,15 @@ const app = express();
 
 // Task rollover scheduler
 const scheduleTaskRollover = () => {
+  // Get current time in PT
   const now = new Date();
-  const midnight = new Date(now);
-  midnight.setHours(24, 0, 0, 0);
   
-  // Calculate milliseconds until midnight
+  // Create midnight in PT timezone
+  const todayStr = now.toISOString().split('T')[0];
+  const midnight = new Date(`${todayStr}T23:59:59.999-07:00`);
+  midnight.setSeconds(midnight.getSeconds() + 1); // Add 1 second to get to next day 00:00:00
+  
+  // Calculate milliseconds until midnight PT
   const msUntilMidnight = midnight.getTime() - now.getTime();
   
   // Schedule the task rollover
@@ -24,14 +28,16 @@ const scheduleTaskRollover = () => {
     try {
       const { TaskService } = require('./services/taskService');
       
-      // Get yesterday's date
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-      yesterday.setHours(0, 0, 0, 0);
+      // Get yesterday's date in PT
+      const now = new Date();
+      const todayStr = now.toISOString().split('T')[0];
+      const yesterdayDate = new Date(todayStr);
+      yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+      const yesterdayStr = yesterdayDate.toISOString().split('T')[0];
       
-      // Get today's date
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
+      // Create explicit PT timezone dates
+      const yesterday = new Date(`${yesterdayStr}T00:00:00-07:00`);
+      const today = new Date(`${todayStr}T00:00:00-07:00`);
       
       // Roll over tasks
       const rolledOverCount = await TaskService.rollOverTasks(yesterday, today);

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -86,13 +86,6 @@ export class TaskService {
     const startOfDay = new Date(`${dateStr}T00:00:00-07:00`);
     const endOfDay = new Date(`${dateStr}T23:59:59.999-07:00`);
 
-    console.log('Getting tasks by date:', {
-      requestedDate: date.toISOString(),
-      startOfDay: startOfDay.toISOString(),
-      endOfDay: endOfDay.toISOString(),
-      serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone
-    });
-
     return this.prisma.task.findMany({
       where: {
         userId,
@@ -216,7 +209,7 @@ export class TaskService {
         }
       }
     });
-
+    
     if (incompleteTasks.length === 0) {
       return 0;
     }

--- a/frontend/src/components/todos/TaskListContainer.tsx
+++ b/frontend/src/components/todos/TaskListContainer.tsx
@@ -35,9 +35,19 @@ export const TaskListContainer: React.FC = () => {
   // Ref to track if component has mounted
   const hasMountedRef = useRef<boolean>(false);
   
+  // Helper function to create a date in PT timezone
+  const createPTDate = (date: Date): Date => {
+    const dateStr = date.toISOString().split('T')[0];
+    return new Date(`${dateStr}T00:00:00-07:00`);
+  };
+
   // Generate date array for the fixed range
   const dateArray = React.useMemo(() => {
-    const today = new Date();
+    // Get today's date in PT timezone
+    const now = new Date();
+    const todayStr = now.toISOString().split('T')[0];
+    const today = new Date(`${todayStr}T00:00:00-07:00`);
+    
     const dates = [];
     
     // Add days before today
@@ -66,7 +76,9 @@ export const TaskListContainer: React.FC = () => {
   [dateArray]);
 
   // Get today's key for highlighting
-  const today = new Date();
+  const now = new Date();
+  const todayStr = now.toISOString().split('T')[0];
+  const today = new Date(`${todayStr}T00:00:00-07:00`);
   const todayKey = today.toISOString().split('T')[0];
 
   // Fetch tasks on component mount

--- a/frontend/src/services/todoApi.ts
+++ b/frontend/src/services/todoApi.ts
@@ -50,7 +50,11 @@ export const todoApi = {
    * Fetch tasks for a specific date
    */
   async fetchTasksByDate(date: Date): Promise<Task[]> {
-    const formattedDate = date.toISOString().split('T')[0];
+    // Ensure the date is in PT timezone
+    const dateStr = date.toISOString().split('T')[0];
+    const ptDate = new Date(`${dateStr}T00:00:00-07:00`);
+    const formattedDate = ptDate.toISOString().split('T')[0];
+    
     const response = await api.get<Task[]>(`/api/tasks/${formattedDate}`);
     return response.data;
   },
@@ -59,7 +63,16 @@ export const todoApi = {
    * Create a new task
    */
   async createTask(task: CreateTaskDTO): Promise<Task> {
-    const response = await api.post<Task>('/api/tasks', task);
+    // Ensure the date is in PT timezone
+    const dateStr = new Date(task.dueDate).toISOString().split('T')[0];
+    const ptDate = new Date(`${dateStr}T00:00:00-07:00`);
+    
+    const ptTask = {
+      ...task,
+      dueDate: ptDate.toISOString()
+    };
+    
+    const response = await api.post<Task>('/api/tasks', ptTask);
     return response.data;
   },
 
@@ -82,7 +95,16 @@ export const todoApi = {
    * Move a task to a different date
    */
   async moveTask(id: string, moveData: MoveTaskDTO): Promise<Task> {
-    const response = await api.put<Task>(`/api/tasks/${id}/move`, moveData);
+    // Ensure the date is in PT timezone
+    const dateStr = new Date(moveData.dueDate).toISOString().split('T')[0];
+    const ptDate = new Date(`${dateStr}T00:00:00-07:00`);
+    
+    const ptMoveData = {
+      ...moveData,
+      dueDate: ptDate.toISOString()
+    };
+    
+    const response = await api.put<Task>(`/api/tasks/${id}/move`, ptMoveData);
     return response.data;
   },
 

--- a/frontend/src/utils/taskUtils.ts
+++ b/frontend/src/utils/taskUtils.ts
@@ -19,10 +19,21 @@ export const calculateDisplayOrder = (
   return Math.floor((prevTask + nextTask) / 2);
 };
 
+// Helper function to create a date in PT timezone
+const createPTDate = (dateStr: string): Date => {
+  // Extract the date part (YYYY-MM-DD)
+  const datePart = new Date(dateStr).toISOString().split('T')[0];
+  // Create a new date with explicit PT timezone
+  return new Date(`${datePart}T00:00:00-07:00`);
+};
+
 // Group tasks by day - optimized version
 export const groupTasksByDay = (tasks: Task[]): Record<string, Task[]> => {
   return tasks.reduce((groups: Record<string, Task[]>, task) => {
-    const dateKey = new Date(task.dueDate).toISOString().split('T')[0];
+    // Create a date object with explicit PT timezone and get the date key
+    const dateObj = createPTDate(task.dueDate);
+    const dateKey = dateObj.toISOString().split('T')[0];
+    
     if (!groups[dateKey]) groups[dateKey] = [];
     groups[dateKey].push(task);
     return groups;


### PR DESCRIPTION
Fix timezone issues with task rollover
- Ensure consistent Pacific Time handling throughout the application
- Fix server rollover scheduling to use explicit PT midnight
- Update frontend date handling to use PT for all date calculations
- Remove debug logging statements