### PR TITLE
Add date picker to task creation and editing components

### DIFF
--- a/frontend/src/components/todos/DayContainer.tsx
+++ b/frontend/src/components/todos/DayContainer.tsx
@@ -87,6 +87,7 @@ export const DayContainer = forwardRef<HTMLDivElement, DayContainerProps>(({
               title={task.title}
               category={task.category as 'Roo Vet' | 'Roo Code' | 'Personal'}
               isPriority={task.isPriority}
+              dueDate={task.dueDate}
               onCancel={() => onEdit('')}
               onSave={onUpdate}
               onDelete={() => onDelete(task.id)}
@@ -113,6 +114,7 @@ export const DayContainer = forwardRef<HTMLDivElement, DayContainerProps>(({
         
         {creatingTaskForDay === dayKey && (
           <TaskCreation
+            dayKey={dayKey}
             onCancel={() => onAddTaskClick(dayKey)}
             onSave={(taskData) => onCreateTask(dayKey, taskData)}
           />

--- a/frontend/src/components/todos/TaskCreation.module.css
+++ b/frontend/src/components/todos/TaskCreation.module.css
@@ -52,6 +52,40 @@
   gap: var(--spacing-2);
 }
 
+.datePickerRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-2);
+}
+
+.datePickerLabel {
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-sm);
+  color: var(--todo-text-color);
+  font-weight: var(--font-weight-medium);
+  min-width: 70px;
+}
+
+.datePicker {
+  flex: 1;
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--todo-border-color);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-sm);
+  color: var(--todo-text-color);
+  background-color: white;
+  transition: all var(--transition-fast);
+  height: 36px;
+}
+
+.datePicker:focus {
+  outline: none;
+  border-color: var(--button-primary-bg);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
 .categorySelect {
   padding: var(--spacing-1) var(--spacing-2);
   border: 1px solid var(--todo-border-color);
@@ -229,6 +263,16 @@
   }
   
   .categorySelect {
+    width: 100%;
+  }
+  
+  .datePickerRow {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+  }
+  
+  .datePicker {
     width: 100%;
   }
 }

--- a/frontend/src/components/todos/TaskCreation.tsx
+++ b/frontend/src/components/todos/TaskCreation.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from 'react';
 import styles from './TaskCreation.module.css';
+import { toDateStringPT, createPTDate } from '../../utils/timezoneUtils';
 
 interface TaskCreationProps {
+  dayKey: string; // The day for which the task is being created
   onCancel?: () => void;
   onSave?: (taskData: {
     title: string;
     category: string;
     isPriority: boolean;
+    dueDate?: string;
   }) => void;
-  // These props will be used when functionality is implemented
-  // For now, they're just placeholders
 }
 
 export const TaskCreation: React.FC<TaskCreationProps> = ({
+  dayKey,
   onCancel,
   onSave,
 }) => {
@@ -20,6 +22,7 @@ export const TaskCreation: React.FC<TaskCreationProps> = ({
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState('Roo Code');
   const [isPriority, setIsPriority] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(dayKey);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<{type: 'success' | 'error', message: string} | null>(null);
 
@@ -35,6 +38,7 @@ export const TaskCreation: React.FC<TaskCreationProps> = ({
           title: title.trim(),
           category,
           isPriority,
+          dueDate: createPTDate(selectedDate).toISOString(),
         });
         
         // Show success feedback briefly
@@ -94,6 +98,18 @@ export const TaskCreation: React.FC<TaskCreationProps> = ({
             />
             High Priority
           </label>
+        </div>
+        
+        <div className={styles.datePickerRow}>
+          <label htmlFor="task-creation-date" className={styles.datePickerLabel}>Due Date:</label>
+          <input
+            id="task-creation-date"
+            type="date"
+            className={styles.datePicker}
+            value={selectedDate}
+            onChange={(e) => setSelectedDate(e.target.value)}
+            aria-label="Task due date"
+          />
         </div>
         
         {feedback && (

--- a/frontend/src/components/todos/TaskEdit.module.css
+++ b/frontend/src/components/todos/TaskEdit.module.css
@@ -52,6 +52,40 @@
   gap: var(--spacing-2);
 }
 
+.datePickerRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-2);
+}
+
+.datePickerLabel {
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-sm);
+  color: var(--todo-text-color);
+  font-weight: var(--font-weight-medium);
+  min-width: 70px;
+}
+
+.datePicker {
+  flex: 1;
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--todo-border-color);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-sm);
+  color: var(--todo-text-color);
+  background-color: white;
+  transition: all var(--transition-fast);
+  height: 36px;
+}
+
+.datePicker:focus {
+  outline: none;
+  border-color: var(--button-primary-bg);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
 .categorySelect {
   padding: var(--spacing-1) var(--spacing-2);
   border: 1px solid var(--todo-border-color);
@@ -252,6 +286,16 @@
   }
   
   .categorySelect {
+    width: 100%;
+  }
+  
+  .datePickerRow {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+  }
+  
+  .datePicker {
     width: 100%;
   }
   

--- a/frontend/src/components/todos/TaskEdit.tsx
+++ b/frontend/src/components/todos/TaskEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styles from './TaskEdit.module.css';
+import { toDateStringPT, createPTDate } from '../../utils/timezoneUtils';
 
 // Define the task category types
 type TaskCategory = 'Roo Vet' | 'Roo Code' | 'Personal';
@@ -9,16 +10,16 @@ interface TaskEditProps {
   title: string;
   category: TaskCategory;
   isPriority: boolean;
+  dueDate: string;
   onCancel?: () => void;
   onSave?: (taskData: {
     id: string;
     title: string;
     category: string;
     isPriority: boolean;
+    dueDate?: string;
   }) => void;
   onDelete?: (id: string) => void;
-  // These props will be used when functionality is implemented
-  // For now, they're just placeholders
 }
 
 export const TaskEdit: React.FC<TaskEditProps> = ({
@@ -26,6 +27,7 @@ export const TaskEdit: React.FC<TaskEditProps> = ({
   title: initialTitle,
   category: initialCategory,
   isPriority: initialIsPriority,
+  dueDate: initialDueDate,
   onCancel,
   onSave,
   onDelete,
@@ -34,6 +36,7 @@ export const TaskEdit: React.FC<TaskEditProps> = ({
   const [title, setTitle] = useState(initialTitle);
   const [category, setCategory] = useState(initialCategory);
   const [isPriority, setIsPriority] = useState(initialIsPriority);
+  const [selectedDate, setSelectedDate] = useState(toDateStringPT(initialDueDate));
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [feedback, setFeedback] = useState<{type: 'success' | 'error', message: string} | null>(null);
@@ -43,7 +46,8 @@ export const TaskEdit: React.FC<TaskEditProps> = ({
     setTitle(initialTitle);
     setCategory(initialCategory);
     setIsPriority(initialIsPriority);
-  }, [initialTitle, initialCategory, initialIsPriority]);
+    setSelectedDate(toDateStringPT(initialDueDate));
+  }, [initialTitle, initialCategory, initialIsPriority, initialDueDate]);
 
   // Handle form submission
   const handleSubmit = async (e: React.FormEvent) => {
@@ -58,6 +62,7 @@ export const TaskEdit: React.FC<TaskEditProps> = ({
           title: title.trim(),
           category,
           isPriority,
+          dueDate: createPTDate(selectedDate).toISOString(),
         });
         
         // Show success feedback briefly
@@ -144,6 +149,18 @@ export const TaskEdit: React.FC<TaskEditProps> = ({
             />
             High Priority
           </label>
+        </div>
+        
+        <div className={styles.datePickerRow}>
+          <label htmlFor="task-date" className={styles.datePickerLabel}>Due Date:</label>
+          <input
+            id="task-date"
+            type="date"
+            className={styles.datePicker}
+            value={selectedDate}
+            onChange={(e) => setSelectedDate(e.target.value)}
+            aria-label="Task due date"
+          />
         </div>
         
         {feedback && (

--- a/frontend/src/components/todos/TaskListContainer.tsx
+++ b/frontend/src/components/todos/TaskListContainer.tsx
@@ -150,11 +150,18 @@ export const TaskListContainer: React.FC = () => {
 
   const handleUpdateTask = async (taskData: any) => {
     try {
-      await updateTask(taskData.id, {
+      const updates: any = {
         title: taskData.title,
         category: taskData.category as 'Roo Vet' | 'Roo Code' | 'Personal',
         isPriority: taskData.isPriority
-      });
+      };
+      
+      // If dueDate is provided, include it in the update
+      if (taskData.dueDate) {
+        updates.dueDate = taskData.dueDate;
+      }
+      
+      await updateTask(taskData.id, updates);
       
       setEditingTaskId(null);
     } catch (error) {

--- a/task-date-picker-implementation-plan.md
+++ b/task-date-picker-implementation-plan.md
@@ -1,0 +1,143 @@
+# Task Date Picker Implementation Plan
+
+## Overview
+
+Currently, the task management system allows users to move tasks between days using drag-and-drop functionality. The user wants to add the ability to set an arbitrary date for a task directly through the UI, making it easier to schedule tasks for future dates without having to drag them.
+
+## Current Implementation
+
+From analyzing the codebase, I've found:
+
+1. Tasks have a `dueDate` field (DateTime type) in the database model.
+2. The frontend represents tasks with a `Task` interface that includes a `dueDate` string.
+3. Tasks can be created through the `TaskCreation` component, which currently doesn't allow date selection.
+4. Tasks can be edited through the `TaskEdit` component, which also doesn't have date selection.
+5. Tasks can be moved between days using drag-and-drop in the `TaskListContainer` component.
+6. The application uses timezone-aware date handling with PT (Pacific Time) as the reference.
+
+## Implementation Plan
+
+### 1. Update TaskEdit Component
+
+Add a date picker to the `TaskEdit` component to allow users to change a task's date:
+
+1. Import a date picker component (we can use a library like react-datepicker or build a custom one).
+2. Add the date picker to the form in `TaskEdit.tsx`.
+3. Add state to manage the selected date.
+4. Update the `handleSubmit` function to include the selected date in the task update.
+5. Update the `TaskEditProps` interface to include the `dueDate` property.
+
+### 2. Update TaskCreation Component
+
+Similarly, add a date picker to the `TaskCreation` component:
+
+1. Import the same date picker component.
+2. Add the date picker to the form in `TaskCreation.tsx`.
+3. Add state to manage the selected date (defaulting to the day for which the task is being created).
+4. Update the `handleSubmit` function to include the selected date.
+
+### 3. Update TodoContext and API Calls
+
+Ensure the context and API calls properly handle the date updates:
+
+1. The existing `updateTask` and `moveTask` functions in `TodoContext.tsx` already handle date changes.
+2. The `todoApi.ts` service already has methods for updating task dates with proper timezone handling.
+
+### 4. UI/UX Considerations
+
+1. Add a calendar icon button next to each task that opens the date picker.
+2. Ensure the date picker is accessible and works well on mobile devices.
+3. Add visual feedback when a task's date is changed.
+4. Consider adding a "quick date" selection for common options (today, tomorrow, next week).
+
+### 5. Testing
+
+1. Test that the date picker correctly displays the current task date.
+2. Test that selecting a new date updates the task correctly.
+3. Test timezone handling to ensure dates are consistent.
+4. Test edge cases like selecting dates in the past or far future.
+
+## Technical Details
+
+### Component Changes
+
+#### TaskEdit.tsx
+
+```tsx
+// Add to imports
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { createPTDate } from '../../utils/timezoneUtils';
+
+// Update TaskEditProps interface
+interface TaskEditProps {
+  id: string;
+  title: string;
+  category: TaskCategory;
+  isPriority: boolean;
+  dueDate: string; // Add this line
+  onCancel?: () => void;
+  onSave?: (taskData: {
+    id: string;
+    title: string;
+    category: string;
+    isPriority: boolean;
+    dueDate?: string; // Add this line
+  }) => void;
+  onDelete?: (id: string) => void;
+}
+
+// Add to component state
+const [selectedDate, setSelectedDate] = useState<Date>(new Date(dueDate));
+
+// Add to form JSX
+<div className={styles.datePickerContainer}>
+  <label>Due Date</label>
+  <DatePicker
+    selected={selectedDate}
+    onChange={(date: Date) => setSelectedDate(date)}
+    dateFormat="yyyy-MM-dd"
+    className={styles.datePicker}
+  />
+</div>
+
+// Update in handleSubmit
+await onSave({
+  id,
+  title: title.trim(),
+  category,
+  isPriority,
+  dueDate: selectedDate.toISOString(), // Add this line
+});
+```
+
+#### TaskCreation.tsx
+
+Similar changes to TaskEdit.tsx, but defaulting the date to the day for which the task is being created.
+
+### CSS Changes
+
+Add styles for the date picker in the respective CSS modules:
+
+```css
+.datePickerContainer {
+  margin-bottom: 10px;
+}
+
+.datePicker {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+```
+
+## Implementation Steps
+
+1. Install a date picker library if needed (e.g., `npm install react-datepicker @types/react-datepicker`).
+2. Update the TaskEdit component to include the date picker.
+3. Update the TaskCreation component to include the date picker.
+4. Add necessary CSS styles for the date picker.
+5. Test the implementation thoroughly.
+
+This implementation will allow users to easily set arbitrary dates for tasks without having to drag them, making the task management system more flexible and user-friendly.


### PR DESCRIPTION
This commit adds the ability to set arbitrary dates for tasks instead of relying on drag-and-drop:
- Added date picker to TaskEdit component
- Added date picker to TaskCreation component
- Updated DayContainer to pass necessary props
- Updated TaskListContainer to handle date updates
- Added CSS styles for date pickers
- Added implementation plan document